### PR TITLE
Fixed typo in DMA channel initialization

### DIFF
--- a/DmaSpi.h
+++ b/DmaSpi.h
@@ -539,7 +539,7 @@ public:
 
   static void begin_setup_rxChannel_impl()
   {
-    txChannel_()->disable();
+    rxChannel_()->disable();
     rxChannel_()->source((volatile uint8_t&)SPI0_POPR);
     rxChannel_()->disableOnCompletion();
     rxChannel_()->triggerAtHardwareEvent(DMAMUX_SOURCE_SPI0_RX);


### PR DESCRIPTION
I'm using the DmaSpi sources as basically an example on a more bare-metal project with the Teensy (no C++ runtime for dynamic allocation, so no new, so it doesn't work out of the box) and found this while copying code around. I suppose this would only very rarely actually cause any issues (if at all) because the channels will be off after powerup, but it's a typo nonetheless.

Also the first time I've ever contributed to an open source project, so yay, I guess.