### PR TITLE
Work with newer versions of Teensyduino

### DIFF
--- a/DmaSpi.h
+++ b/DmaSpi.h
@@ -572,7 +572,7 @@ extern DmaSpi0 DMASPI0;
 
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 
-class DmaSpi1 : public AbstractDmaSpi<DmaSpi1, SPI1Class, SPI1>
+class DmaSpi1 : public AbstractDmaSpi<DmaSpi1, SPIClass, SPI1>
 {
 public:
   static void begin_setup_txChannel_impl()
@@ -615,7 +615,7 @@ private:
 };
 
 /*
-class DmaSpi2 : public AbstractDmaSpi<DmaSpi2, SPI2Class, SPI2>
+class DmaSpi2 : public AbstractDmaSpi<DmaSpi2, SPIClass, SPI2>
 {
 public:
   static void begin_setup_txChannel_impl()
@@ -707,7 +707,7 @@ public:
 private:
 };
 
-class DmaSpi1 : public AbstractDmaSpi<DmaSpi1, SPI1Class, SPI1>
+class DmaSpi1 : public AbstractDmaSpi<DmaSpi1, SPIClass, SPI1>
 {
 public:
   static void begin_setup_txChannel_impl()
@@ -735,8 +735,16 @@ public:
     SPI1_C2 |= SPI_C2_TXDMAE | SPI_C2_RXDMAE;
   }
 
+//  static void dumpCFG(const char *sz, uint32_t* p)
+//  {
+//    DMASPI_PRINT(("%s: %x %x %x %x \n", sz, p[0], p[1], p[2], p[3]));
+//  }
+  
   static void post_cs_impl()
   {
+    DMASPI_PRINT(("post_cs S C1 C2: %x %x %x\n", SPI1_S, SPI1_C1, SPI1_C2));
+//    dumpCFG("RX", (uint32_t*)(void*)rxChannel_()->CFG);
+//    dumpCFG("TX", (uint32_t*)(void*)txChannel_()->CFG);
     rxChannel_()->enable();
     txChannel_()->enable();
   }

--- a/examples/DMASpi_example2/DMASpi_example2.ino
+++ b/examples/DMASpi_example2/DMASpi_example2.ino
@@ -1,0 +1,252 @@
+//#include <WProgram.h>
+
+#include <SPI.h>
+#include <DmaSpi.h>
+
+/** Important
+  The sketch waits for user input through Serial (USB) before it starts the setup.
+  After any key was pressed, it should begin to work. It will ask for a second keypress later.
+  
+  This example cannot simply be modified to use SPI1 or SPI2 instead of SPI0 because ActiveLowChipSelect is
+  hardcoded to use SPI (SPI0).
+  If you want to use SPI1 or SPI2, you need to create a new chip select class to reflect this.
+**/
+
+/** Hardware setup:
+ Teensy 3.1, 3.2: DOUT (11) connected to DIN (12)
+ Teensy LC: DOUT (11) connected to DIN (12)
+ Teensy 3.5, 3.6: DOUT (11) connected to DIN (12)
+**/
+
+/** buffers to send from and to receive to **/
+#define DMASIZE 100
+uint8_t src[DMASIZE];
+volatile uint8_t dest[DMASIZE];
+volatile uint8_t dest1[DMASIZE];
+
+/** Wait for and consume a keypress over USB **/
+void waitForKeyPress()
+{
+  Serial.println("\nPress a key to continue\n");
+  while(!Serial.available());
+  while(Serial.available())
+  {
+    Serial.read();
+  }
+}
+
+void dumpBuffer(const volatile uint8_t* buf, const char* prefix)
+{
+  Serial.print(prefix);
+  for (size_t i = 0; i < DMASIZE; i++)
+  {
+    Serial.printf("0x%02x ", buf[i]);
+  }
+  Serial.print('\n');
+}
+/** Compare the buffers and print the destination contents if there's a mismatch **/
+void compareBuffers(const uint8_t* src_, const uint8_t* dest_)
+{
+  int n = memcmp((const void*)src_, (const void*)dest_, DMASIZE);
+  if (n == 0)
+  {
+    Serial.println("src and dest match");
+  }
+  else
+  {
+    Serial.println("src and dest don't match");
+    dumpBuffer(src_, " src: " );
+    dumpBuffer(dest_, "dest: ");
+  }
+}
+
+void setSrc()
+{
+  for (size_t i = 0; i < DMASIZE; i++)
+  {
+    src[i] = i;
+  }
+}
+
+void clrDest(uint8_t* dest_)
+{
+  memset((void*)dest_, 0x00, DMASIZE);
+}
+
+void setup()
+{
+  waitForKeyPress();
+  Serial.println("Hi!");
+
+  /** Prepare source and destination **/
+  setSrc();
+  clrDest((uint8_t*)dest);
+  Serial.println("Buffers are prepared");Serial.flush();
+
+  /** set up SPI **/
+  SPISettings spiSettings;
+  SPI1.begin();
+
+  // transmit 10 bytes and measure time to get a feel of how long that takes
+  SPI1.beginTransaction(spiSettings);
+  elapsedMicros us;
+  for (size_t i = 0; i < DMASIZE; i++)
+  {
+    dest[i] = SPI1.transfer(src[i]);
+  }
+  uint32_t t = us;
+  Serial.print("Time for non-DMA transfer: ");Serial.print(t);Serial.println("us");
+  SPI1.endTransaction();
+  compareBuffers(src, (const uint8_t*)dest);
+
+  waitForKeyPress();
+
+  DMASPI1.begin();
+  DMASPI1.start();
+
+
+  DmaSpi::Transfer trx(nullptr, 0, nullptr);
+
+  Serial.println("Testing src -> dest, single transfer");
+  Serial.println("--------------------------------------------------");
+  trx = DmaSpi::Transfer(src, DMASIZE, dest);
+  clrDest((uint8_t*)dest);
+  DMASPI1.registerTransfer(trx);
+  while(trx.busy())
+  {
+  }
+  Serial.println("Finished DMA transfer");
+  compareBuffers(src, (const uint8_t*)dest);
+  Serial.println("==================================================\n\n");
+
+
+  Serial.println("Testing src -> discard, single transfer");
+  Serial.println("--------------------------------------------------");
+  trx = DmaSpi::Transfer(src, DMASIZE, nullptr);
+  DMASPI1.registerTransfer(trx);
+  while(trx.busy())
+  {
+  }
+  Serial.println("Finished DMA transfer");
+  Serial.printf("last discarded value is 0x%02x\n", DMASPI1.devNull());
+  if (DMASPI1.devNull() == src[DMASIZE-1])
+  {
+    Serial.println("That appears to be correct");
+  }
+  else
+  {
+    Serial.printf("That appears to be wrong, it should be src[DMASIZE-1] which is 0x%02x\n", src[DMASIZE-1]);
+  }
+  Serial.println("==================================================\n\n");
+
+
+  Serial.println("Testing 0xFF dummy data -> dest, single transfer");
+  Serial.println("--------------------------------------------------");
+  trx = DmaSpi::Transfer(nullptr, DMASIZE, dest, 0xFF);
+  memset((void*)src, 0xFF, DMASIZE); // we need this for checking the dest buffer
+  clrDest((uint8_t*)dest);
+  DMASPI1.registerTransfer(trx);
+  while(trx.busy())
+  {
+  }
+  Serial.println("Finished DMA transfer");
+  compareBuffers(src, (const uint8_t*)dest);
+  Serial.println("==================================================\n\n");
+
+
+  Serial.println("Testing multiple queued transfers");
+  Serial.println("--------------------------------------------------");
+  trx = DmaSpi::Transfer(src, DMASIZE, dest, 0xFF);
+  setSrc();
+  clrDest((uint8_t*)dest);
+  clrDest((uint8_t*)dest1);
+  DmaSpi::Transfer trx1(src, DMASIZE, dest1);
+  DMASPI1.registerTransfer(trx);
+  DMASPI1.registerTransfer(trx1);
+  while(trx.busy());
+  Serial.println("Finished DMA transfer");
+  while(trx1.busy());
+  Serial.println("Finished DMA transfer1");
+  compareBuffers(src, (const uint8_t*)dest);
+  compareBuffers(src, (const uint8_t*)dest1);
+  Serial.println("==================================================\n\n");
+
+
+  Serial.println("Testing pause and restart");
+  Serial.println("--------------------------------------------------");
+  clrDest((uint8_t*)dest);
+  clrDest((uint8_t*)dest1);
+  DMASPI1.registerTransfer(trx);
+  DMASPI1.registerTransfer(trx1);
+  DMASPI1.stop();
+  us = elapsedMicros();
+  while(!DMASPI1.stopped());
+  t = us;
+  while(trx.busy());
+  Serial.printf("Time until stopped: %lu us\n", t);
+  Serial.println("Finished DMA transfer");
+
+  if (DMASPI1.stopped())
+  {
+    Serial.println("DMA SPI appears to have stopped (this is good)\nrestarting");
+  }
+  else
+  {
+    Serial.println("DMA SPI does not report stopped state, but it should. (this is bad)");
+  }
+
+  DMASPI1.start();
+  while(trx1.busy());
+  Serial.println("Finished DMA transfer1");
+  compareBuffers(src, (const uint8_t*)dest);
+  compareBuffers(src, (const uint8_t*)dest1);
+  Serial.println("==================================================\n\n");
+
+
+  Serial.println("Testing src -> dest, with chip select object");
+  Serial.println("--------------------------------------------------");
+  ActiveLowChipSelect cs(0, SPISettings());
+//  DebugChipSelect cs;
+  trx = DmaSpi::Transfer(src, DMASIZE, dest, 0, &cs);
+  clrDest((uint8_t*)dest);
+  DMASPI1.registerTransfer(trx);
+  while(trx.busy())
+  {
+  }
+  Serial.println("Finished DMA transfer");
+  compareBuffers(src, (const uint8_t*)dest);
+  Serial.println("==================================================\n\n");
+
+
+  DmaSpi::Transfer(src, DMASIZE, dest, 0, &cs);
+
+  if (DMASPI1.stopped())
+  {
+    Serial.println("DMA SPI stopped.");
+  }
+  else
+  {
+    Serial.println("DMA SPI is still running");
+  }
+  DMASPI1.stop();
+  if (DMASPI1.stopped())
+  {
+    Serial.println("DMA SPI stopped.");
+  }
+  else
+  {
+    Serial.println("DMA SPI is still running");
+  }
+
+  DMASPI1.end();
+  SPI1.end();
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop()
+{
+  digitalWriteFast(LED_BUILTIN, true);
+  delay(500);
+  digitalWriteFast(LED_BUILTIN, false);
+  delay(500);
+}


### PR DESCRIPTION
Newer versions of Teensyduino has SPI as one class not subclasses

Add second example - Optional but I had it on my machine to test using SPI1 instead of SPI
